### PR TITLE
Integrate Firebase auth and Firestore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+package-lock.json
+package.json

--- a/New/html/index.html
+++ b/New/html/index.html
@@ -312,6 +312,9 @@
     </div>
   </div>
 
+  <script type="module" src="../js/firebase.js"></script>
+  <script type="module" src="../js/auth.js"></script>
+  <script type="module" src="../js/chat.js"></script>
   <script src="../js/config.js"></script>
   <script src="../js/open.js"></script>
   <script src="../js/register.js"></script>

--- a/New/js/auth.js
+++ b/New/js/auth.js
@@ -1,0 +1,34 @@
+// auth.js: Firebase Authentication helper functions
+import { createUserWithEmailAndPassword, signInWithEmailAndPassword, signOut } from 'https://www.gstatic.com/firebasejs/10.12.0/firebase-auth.js';
+
+export async function signUp(email, password) {
+  try {
+    const userCredential = await createUserWithEmailAndPassword(firebaseAuth, email, password);
+    alert('ユーザー登録成功！');
+    return userCredential;
+  } catch (error) {
+    alert('エラー: ' + error.message);
+    throw error;
+  }
+}
+
+export async function login(email, password) {
+  try {
+    const userCredential = await signInWithEmailAndPassword(firebaseAuth, email, password);
+    alert('ログイン成功！');
+    return userCredential;
+  } catch (error) {
+    alert('エラー: ' + error.message);
+    throw error;
+  }
+}
+
+export async function logout() {
+  await signOut(firebaseAuth);
+  alert('ログアウトしました');
+}
+
+// expose globally for non-module scripts
+window.signUp = signUp;
+window.login = login;
+window.logout = logout;

--- a/New/js/chat.js
+++ b/New/js/chat.js
@@ -1,0 +1,23 @@
+// chat.js: basic Firestore chat utilities
+import { collection, addDoc, serverTimestamp, query, orderBy, onSnapshot } from 'https://www.gstatic.com/firebasejs/10.12.0/firebase-firestore.js';
+
+export async function sendMessage(uid, message) {
+  await addDoc(collection(firebaseDb, 'chats'), {
+    uid,
+    message,
+    timestamp: serverTimestamp()
+  });
+}
+
+export function subscribeToChat(callback) {
+  const q = query(collection(firebaseDb, 'chats'), orderBy('timestamp'));
+  onSnapshot(q, (snapshot) => {
+    const messages = [];
+    snapshot.forEach(doc => messages.push(doc.data()));
+    callback(messages);
+  });
+}
+
+// expose globally
+window.sendMessage = sendMessage;
+window.subscribeToChat = subscribeToChat;

--- a/New/js/chat_system.js
+++ b/New/js/chat_system.js
@@ -73,6 +73,10 @@ class ChatSystem {
 
     // ユーザーメッセージを追加
     this.addMessage(type, message, 'user');
+    if (window.sendMessage && firebaseAuth.currentUser) {
+      // Firestoreに保存
+      sendMessage(firebaseAuth.currentUser.uid, message);
+    }
     
     // 入力欄をクリア
     input.value = '';
@@ -90,6 +94,9 @@ class ChatSystem {
       const response = await this.getAIResponse(type, message);
       this.hideTypingIndicator(type);
       this.addMessage(type, response, 'ai');
+      if (window.sendMessage && firebaseAuth.currentUser) {
+        sendMessage(firebaseAuth.currentUser.uid, response);
+      }
       console.log('✅ Chat System: AI response received successfully');
     } catch (error) {
       console.error('❌ Chat System Error:', error);

--- a/New/js/firebase.js
+++ b/New/js/firebase.js
@@ -1,0 +1,25 @@
+// firebase.js: Initialize Firebase and expose Auth and Firestore
+import { initializeApp } from 'https://www.gstatic.com/firebasejs/10.12.0/firebase-app.js';
+import { getAnalytics } from 'https://www.gstatic.com/firebasejs/10.12.0/firebase-analytics.js';
+import { getAuth } from 'https://www.gstatic.com/firebasejs/10.12.0/firebase-auth.js';
+import { getFirestore } from 'https://www.gstatic.com/firebasejs/10.12.0/firebase-firestore.js';
+
+// TODO: Replace with your project's Firebase configuration
+const firebaseConfig = {
+  apiKey: 'YOUR_API_KEY',
+  authDomain: 'YOUR_AUTH_DOMAIN',
+  projectId: 'YOUR_PROJECT_ID',
+  storageBucket: 'YOUR_STORAGE_BUCKET',
+  messagingSenderId: 'YOUR_MESSAGING_SENDER_ID',
+  appId: 'YOUR_APP_ID',
+  measurementId: 'YOUR_MEASUREMENT_ID'
+};
+
+const app = initializeApp(firebaseConfig);
+getAnalytics(app);
+export const auth = getAuth(app);
+export const db = getFirestore(app);
+
+// Expose to global scope for non-module scripts
+window.firebaseAuth = auth;
+window.firebaseDb = db;

--- a/New/js/login.js
+++ b/New/js/login.js
@@ -6,23 +6,15 @@ document.addEventListener('DOMContentLoaded', () => {
     loginForm.addEventListener('submit', function(e) {
       e.preventDefault();
 
-      // ------ テスト用：何を入力してもホーム画面へ進む ------
-      showScreen('home-screen');
-
-      /* ------ 本来の認証処理（DB連携/LocalStorage用） ------
       const email = loginForm.elements['email'].value;
       const password = loginForm.elements['password'].value;
-      // 例：localStorageから値を取得して認証
-      if (
-        email === localStorage.getItem('userEmail') &&
-        password === localStorage.getItem('userPassword')
-      ) {
-        showScreen('home-screen');
-      } else {
-        alert('メールアドレスまたはパスワードが違います');
-      }
-      // ------ 本来の認証ここまで ------
-      */
+      login(email, password)
+        .then(() => {
+          showScreen('home-screen');
+        })
+        .catch(() => {
+          // エラー処理はlogin内でアラート表示
+        });
     });
   }
 });

--- a/New/js/register.js
+++ b/New/js/register.js
@@ -23,12 +23,16 @@ document.addEventListener('DOMContentLoaded', () => {
         return;
       }
       
-      // 仮でlocalStorage保存
-      localStorage.setItem('userEmail', email);
-      localStorage.setItem('userPassword', password);
-      // 登録フォーム非表示、ヒアリング質問表示
-      regForm.style.display = 'none';
-      showDropdownQuestions();
+      // Firebaseでユーザー登録
+      signUp(email, password)
+        .then(() => {
+          // 登録フォーム非表示、ヒアリング質問表示
+          regForm.style.display = 'none';
+          showDropdownQuestions();
+        })
+        .catch(() => {
+          // エラー処理はsignUp内でアラート表示
+        });
     });
   }
 


### PR DESCRIPTION
## Summary
- set up Firebase initialization in `firebase.js`
- add authentication helpers in `auth.js`
- add Firestore chat helpers in `chat.js`
- wire registration/login screens to Firebase
- store chat messages in Firestore
- load Firebase modules in `index.html`
- ignore node modules with `.gitignore`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6847975894e4832fa14f658bf0b9248d