### PR TITLE
Replace hard coded API key with env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Example environment configuration
+GEMINI_API_KEY=your_google_ai_studio_api_key

--- a/New/js/ai_api.js
+++ b/New/js/ai_api.js
@@ -2,10 +2,10 @@
 
 class AIAPIService {
   constructor() {
-    // 本番環境では環境変数や設定ファイルから取得
-    this.apiKey = 'AIzaSyCDBqwf19rjKWOtPB7J-ZTHSTiV2-RRLRA'; // 実際のAPIキーに置き換え
+    // 環境変数からAPIキーを取得
+    this.apiKey = process.env.GEMINI_API_KEY || 'YOUR_GOOGLE_AI_STUDIO_API_KEY';
     this.baseUrl = 'https://generativelanguage.googleapis.com/v1/models/gemini-1.5-flash:generateContent';
-    this.isEnabled = true; // 実際のAPIキーが設定されているかどうか
+    this.isEnabled = this.apiKey && this.apiKey !== 'YOUR_GOOGLE_AI_STUDIO_API_KEY' && this.apiKey.trim() !== '';
     
     console.log('🚀 AIAPIService initialized with key:', this.apiKey ? 'VALID' : 'MISSING');
     console.log('🔧 API Enabled:', this.isEnabled);

--- a/New/js/config.js
+++ b/New/js/config.js
@@ -3,9 +3,9 @@
 const AppConfig = {
   // Google AI Studio API設定
   ai: {
-    // 実際のAPIキーをここに設定してください
-    // Google AI Studioで取得したAPIキーに置き換えてください
-    apiKey: 'AIzaSyCDBqwf19rjKWOtPB7J-ZTHSTiV2-RRLRA',
+    // Google AI Studio APIキー
+    // 環境変数 GEMINI_API_KEY を参照し、未設定の場合はプレースホルダーを使用
+    apiKey: process.env.GEMINI_API_KEY || 'YOUR_GOOGLE_AI_STUDIO_API_KEY',
     
     // APIが無効の場合はフォールバック応答を使用
     enableFallback: true,

--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Job Hunting App
+
+This project requires a Gemini API key for AI features.
+
+## Setup
+
+1. Copy `.env.example` to `.env`.
+2. Edit `.env` and set `GEMINI_API_KEY` to your Google AI Studio API key.
+3. Open `New/html/index.html` in your browser to run the app.
+


### PR DESCRIPTION
## Summary
- reference `process.env.GEMINI_API_KEY` in config and api service
- provide `.env.example` with example key
- add setup instructions to `README`

## Testing
- `grep -R "AIza" -n || true`

------
https://chatgpt.com/codex/tasks/task_e_68478f2d4170832fa4134063a26da0ea