### PR TITLE
Use safer source for API key

### DIFF
--- a/New/js/ai_api.js
+++ b/New/js/ai_api.js
@@ -1,9 +1,30 @@
 // ai_api.js: Google AI Studio API連携
 
+function getInitialApiKey() {
+  if (typeof window !== 'undefined') {
+    if (window.GEMINI_API_KEY) {
+      return window.GEMINI_API_KEY;
+    }
+    const meta = document.querySelector('meta[name="gemini-api-key"]');
+    if (meta && meta.content) {
+      return meta.content;
+    }
+    try {
+      const stored = localStorage.getItem('jobHuntingApp_apiKey');
+      if (stored) {
+        return stored;
+      }
+    } catch (e) {
+      // ignore access issues
+    }
+  }
+  return 'YOUR_GOOGLE_AI_STUDIO_API_KEY';
+}
+
 class AIAPIService {
   constructor() {
-    // 環境変数からAPIキーを取得
-    this.apiKey = process.env.GEMINI_API_KEY || 'YOUR_GOOGLE_AI_STUDIO_API_KEY';
+    // 安全なソースからAPIキーを取得
+    this.apiKey = getInitialApiKey();
     this.baseUrl = 'https://generativelanguage.googleapis.com/v1/models/gemini-1.5-flash:generateContent';
     this.isEnabled = this.apiKey && this.apiKey !== 'YOUR_GOOGLE_AI_STUDIO_API_KEY' && this.apiKey.trim() !== '';
     

--- a/New/js/config.js
+++ b/New/js/config.js
@@ -1,11 +1,32 @@
 // config.js: アプリケーション設定
 
+function getInitialApiKey() {
+  if (typeof window !== 'undefined') {
+    if (window.GEMINI_API_KEY) {
+      return window.GEMINI_API_KEY;
+    }
+    const meta = document.querySelector('meta[name="gemini-api-key"]');
+    if (meta && meta.content) {
+      return meta.content;
+    }
+    try {
+      const stored = localStorage.getItem('jobHuntingApp_apiKey');
+      if (stored) {
+        return stored;
+      }
+    } catch (e) {
+      // ignore access issues
+    }
+  }
+  return 'YOUR_GOOGLE_AI_STUDIO_API_KEY';
+}
+
 const AppConfig = {
   // Google AI Studio API設定
   ai: {
     // Google AI Studio APIキー
-    // 環境変数 GEMINI_API_KEY を参照し、未設定の場合はプレースホルダーを使用
-    apiKey: process.env.GEMINI_API_KEY || 'YOUR_GOOGLE_AI_STUDIO_API_KEY',
+    // window 変数、meta タグ、localStorage の順に取得
+    apiKey: getInitialApiKey(),
     
     // APIが無効の場合はフォールバック応答を使用
     enableFallback: true,


### PR DESCRIPTION
## Summary
- read the Gemini API key from `window`, `<meta>` tag, or localStorage
- avoid `process.env` so browser loads don't throw a `ReferenceError`

## Testing
- `node -e "require('./New/js/config.js')"`
- `node -e "require('./New/js/ai_api.js')"`


------
https://chatgpt.com/codex/tasks/task_e_6847b2c240a8832fa309e4857e6af540