### PR TITLE
Remove duplicate firebase init script

### DIFF
--- a/New/html/index.html
+++ b/New/html/index.html
@@ -318,7 +318,6 @@
 
 
   <script src="../js/config.js"></script>
-  <script type="module" src="../js/firebase_init.js"></script>
   <script src="../js/open.js"></script>
   <script src="../js/register.js"></script>
   <script src="../js/login.js"></script>


### PR DESCRIPTION
## Summary
- remove duplicated initialization script from `index.html`
- keep compat Firebase loading order consistent

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6847b2c44b54832f8c0d1c7ce70b23a1