### PR TITLE
Refactor analysis chat setup

### DIFF
--- a/New/css/style.css
+++ b/New/css/style.css
@@ -862,7 +862,8 @@ button.success:hover, .button.success:hover {
   border-color: var(--primary-color);
 }
 
-.timeline-step.done {
+.timeline-step.done,
+.flow-step.done {
   background: var(--primary-color);
   color: var(--light-text);
   border-color: var(--primary-color);
@@ -948,10 +949,7 @@ button.success:hover, .button.success:hover {
 }
 
 .flow-step.done {
-  background: var(--primary-color);
-  color: var(--light-text);
   opacity: 1;
-  border-color: var(--primary-color);
 }
 
 /* 進捗パーセンテージバー */

--- a/New/html/index.html
+++ b/New/html/index.html
@@ -329,6 +329,7 @@
   <script type="module" src="../js/register.js"></script>
   <script type="module" src="../js/login.js"></script>
   <script src="../js/ai_api.js"></script>
+  <script src="../js/analysis_generic.js"></script>
   <script src="../js/analysis_self.js"></script>
   <script src="../js/analysis_company.js"></script>
   <script src="../js/analysis_industry.js"></script>

--- a/New/js/analysis_company.js
+++ b/New/js/analysis_company.js
@@ -1,39 +1,8 @@
 // analysis_company.js: 企業分析チャットUI仮実装
-
-document.addEventListener('DOMContentLoaded', () => {
-  const screen = document.getElementById('analysis-company-screen');
-  if (!screen) return;
-
-  const chatArea = screen.querySelector('#chat-messages-company'); // 修正
-  if (!chatArea) { // chatAreaが見つからなかった場合のエラーハンドリングを追加
-    console.error('Error: Chat area element not found in analysis_company-screen');
-    return;
-  }
-
-  const input = document.createElement('input');
-  input.type = 'text';
-  input.placeholder = '企業名や気になる業界の特徴を入力...';
-
-  const sendBtn = document.createElement('button');
-  sendBtn.textContent = '送信';
-
-  chatArea.innerHTML = '<div class="chat-message system">企業分析のお手伝いをします。質問や知りたい企業名を入力してください。</div>';
-  chatArea.appendChild(input);
-  chatArea.appendChild(sendBtn);
-
-  sendBtn.addEventListener('click', () => {
-    const text = input.value.trim();
-    if (!text) return;
-    const userMsg = document.createElement('div');
-    userMsg.className = 'chat-message user';
-    userMsg.textContent = text;
-    chatArea.insertBefore(userMsg, input);
-    input.value = '';
-    setTimeout(() => {
-      const aiMsg = document.createElement('div');
-      aiMsg.className = 'chat-message ai';
-      aiMsg.textContent = '（AIの応答例）入力いただいた企業情報や特徴について解説します。';
-      chatArea.insertBefore(aiMsg, input);
-    }, 600);
-  });
+setupAnalysisChat({
+  screenId: 'analysis-company-screen',
+  chatId: 'chat-messages-company',
+  placeholder: '企業名や気になる業界の特徴を入力...',
+  systemMessage: '企業分析のお手伝いをします。質問や知りたい企業名を入力してください。',
+  aiResponse: '（AIの応答例）入力いただいた企業情報や特徴について解説します。'
 });

--- a/New/js/analysis_generic.js
+++ b/New/js/analysis_generic.js
@@ -1,0 +1,40 @@
+function setupAnalysisChat({screenId, chatId, placeholder, systemMessage, aiResponse}) {
+  document.addEventListener('DOMContentLoaded', () => {
+    const screen = document.getElementById(screenId);
+    if (!screen) return;
+    const chatArea = screen.querySelector(`#${chatId}`);
+    if (!chatArea) {
+      console.error(`Error: Chat area element not found in ${screenId}`);
+      return;
+    }
+
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.placeholder = placeholder;
+
+    const sendBtn = document.createElement('button');
+    sendBtn.textContent = '送信';
+
+    chatArea.innerHTML = `<div class="chat-message system">${systemMessage}</div>`;
+    chatArea.appendChild(input);
+    chatArea.appendChild(sendBtn);
+
+    sendBtn.addEventListener('click', () => {
+      const text = input.value.trim();
+      if (!text) return;
+      const userMsg = document.createElement('div');
+      userMsg.className = 'chat-message user';
+      userMsg.textContent = text;
+      chatArea.insertBefore(userMsg, input);
+      input.value = '';
+      setTimeout(() => {
+        const aiMsg = document.createElement('div');
+        aiMsg.className = 'chat-message ai';
+        aiMsg.textContent = aiResponse;
+        chatArea.insertBefore(aiMsg, input);
+      }, 600);
+    });
+  });
+}
+
+window.setupAnalysisChat = setupAnalysisChat;

--- a/New/js/analysis_industry.js
+++ b/New/js/analysis_industry.js
@@ -1,39 +1,8 @@
 // analysis_industry.js: 業界分析チャットUI仮実装
-
-document.addEventListener('DOMContentLoaded', () => {
-  const screen = document.getElementById('analysis-industry-screen');
-  if (!screen) return;
-
-  const chatArea = screen.querySelector('#chat-messages-industry'); // 修正
-  if (!chatArea) { // chatAreaが見つからなかった場合のエラーハンドリングを追加
-    console.error('Error: Chat area element not found in analysis_industry-screen');
-    return;
-  }
-
-  const input = document.createElement('input');
-  input.type = 'text';
-  input.placeholder = '知りたい業界や分野を入力...';
-
-  const sendBtn = document.createElement('button');
-  sendBtn.textContent = '送信';
-
-  chatArea.innerHTML = '<div class="chat-message system">業界分析に関する質問や関心のある分野を入力してください。</div>';
-  chatArea.appendChild(input);
-  chatArea.appendChild(sendBtn);
-
-  sendBtn.addEventListener('click', () => {
-    const text = input.value.trim();
-    if (!text) return;
-    const userMsg = document.createElement('div');
-    userMsg.className = 'chat-message user';
-    userMsg.textContent = text;
-    chatArea.insertBefore(userMsg, input);
-    input.value = '';
-    setTimeout(() => {
-      const aiMsg = document.createElement('div');
-      aiMsg.className = 'chat-message ai';
-      aiMsg.textContent = '（AIの応答例）入力いただいた業界の最新情報や動向についてご案内します。';
-      chatArea.insertBefore(aiMsg, input);
-    }, 600);
-  });
+setupAnalysisChat({
+  screenId: 'analysis-industry-screen',
+  chatId: 'chat-messages-industry',
+  placeholder: '知りたい業界や分野を入力...',
+  systemMessage: '業界分析に関する質問や関心のある分野を入力してください。',
+  aiResponse: '（AIの応答例）入力いただいた業界の最新情報や動向についてご案内します。'
 });

--- a/New/js/analysis_self.js
+++ b/New/js/analysis_self.js
@@ -1,43 +1,8 @@
 // analysis_self.js: 自己分析チャットUI仮実装
-
-document.addEventListener('DOMContentLoaded', () => {
-  const screen = document.getElementById('analysis-self-screen');
-  if (!screen) return;
-
-  const chatArea = screen.querySelector('#chat-messages-self'); // 修正
-  if (!chatArea) { // chatAreaが見つからなかった場合のエラーハンドリングを追加
-    console.error('Error: Chat area element not found in analysis_self-screen');
-    return;
-  }
-
-  const input = document.createElement('input');
-  input.type = 'text';
-  input.placeholder = '自己分析に関する質問や悩みを入力...';
-
-  const sendBtn = document.createElement('button');
-  sendBtn.textContent = '送信';
-
-  // 初回メッセージ
-  chatArea.innerHTML = '<div class="chat-message system">自己分析のサポートをします。何でも入力してください。</div>';
-  chatArea.appendChild(input);
-  chatArea.appendChild(sendBtn);
-
-  sendBtn.addEventListener('click', () => {
-    const text = input.value.trim();
-    if (!text) return;
-    // ユーザー発言を追加
-    const userMsg = document.createElement('div');
-    userMsg.className = 'chat-message user';
-    userMsg.textContent = text;
-    chatArea.insertBefore(userMsg, input);
-    input.value = '';
-    // 仮のAI応答
-    setTimeout(() => {
-      const aiMsg = document.createElement('div');
-      aiMsg.className = 'chat-message ai';
-      aiMsg.textContent = '（AIの応答例）あなたの強みや価値観について一緒に考えましょう。';
-      chatArea.insertBefore(aiMsg, input);
-    }, 600);
-  });
+setupAnalysisChat({
+  screenId: 'analysis-self-screen',
+  chatId: 'chat-messages-self',
+  placeholder: '自己分析に関する質問や悩みを入力...',
+  systemMessage: '自己分析のサポートをします。何でも入力してください。',
+  aiResponse: '（AIの応答例）あなたの強みや価値観について一緒に考えましょう。'
 });
-


### PR DESCRIPTION
## Summary
- create `analysis_generic.js` helper to handle simple analysis chat setup
- shrink each analysis script to use the shared helper
- reference the new helper in `index.html`
- consolidate duplicated CSS for `.timeline-step.done` and `.flow-step.done`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6847d419a6fc832f8493e6b953c7f9d0